### PR TITLE
Fix compiler warnings

### DIFF
--- a/ISXDK/35/include/ISUI/LGUIElement.h
+++ b/ISXDK/35/include/ISUI/LGUIElement.h
@@ -628,7 +628,7 @@ public:
 
 	virtual LGUIElement *CreateUIElement(LGUIElement *pParent, const char *Name, class XMLNode *pXML, const char *Template = 0)
 	{
-		T *pElement = new T(Type,pParent,Name);
+		T *pElement = new T((char*)Type,pParent,(char*)Name);
 		
 		if (!pElement->FromXML(pXML,g_UIManager.FindTemplate(Template)))
 		{
@@ -644,7 +644,7 @@ public:
 
 	virtual LGUIElement *CreateUIElement(LGUIElement *pParent, const char *Name)
 	{
-		T *pElement = new T(Type,pParent,Name);
+		T *pElement = new T((char*)Type,pParent,(char*)Name);
 		Elements[pElement]=1;
 		return pElement;
 	}

--- a/ISXDK/35/include/Index.h
+++ b/ISXDK/35/include/Index.h
@@ -107,9 +107,9 @@ public:
 		return ret;
 	}
 
-	virtual void *Malloc(size_t Size)
+	virtual void *Malloc(size_t _Size)
 	{
-		return malloc(Size);
+		return malloc(_Size);
 	}
 	virtual void Free(const void *mem)
 	{


### PR DESCRIPTION
We have our libraries set up so that some compiler warnings are treated as errors.   The changes in this pull request were necessary to remove these warnings/errors.

Please let me know if the warnings we're seeing are not apparent from the diff below.  I can always get the actual warning message, etc.

Also, if you prefer I fix the issue in another way, just let me know and I'll use a different method.  These alterations just seemed the easiest and most straight-forward way of dealing with the warnings/errors.

Thanks!
